### PR TITLE
Add option to use internal runtimes over runtimes on cart 

### DIFF
--- a/rootfs/usr/bin/kazeta
+++ b/rootfs/usr/bin/kazeta
@@ -98,20 +98,27 @@ if [[ ! -d "${upper}" ]]; then
 	mkdir -p "${upper}"
 fi
 
+#Directory for all internal runtimes
+internal_runtime="/usr/share/kazeta/runtimes/"
+
 runtime_name="$(get_attribute 'Runtime' ${cart_info})"
 if [ -n "$runtime_name" ]; then
-	runtime="${media_path}/${runtime_name}"
+	#Checks for a runtime internally that matches
+	runtime="$(ls ${internal_runtime}/${runtime_name}-*.kzr)"
 	if [ ! -f "$runtime" ]; then
-		runtime="${media_path}/${runtime_name}.kzr"
+		runtime="${media_path}/${runtime_name}"
 		if [ ! -f "$runtime" ]; then
-			runtime="$(ls ${media_path}/${runtime_name}-*.kzr)"
+			runtime="${media_path}/${runtime_name}.kzr"
 			if [ ! -f "$runtime" ]; then
-				runtime="/usr/share/kazeta/runtimes/none.kzr"
+				runtime="$(ls ${media_path}/${runtime_name}-*.kzr)"
+				if [ ! -f "$runtime" ]; then
+					runtime="{$internal_runtime}/none.kzr"
+				fi
 			fi
 		fi
 	fi
 else
-	runtime="/usr/share/kazeta/runtimes/none.kzr"
+	runtime="{$internal_runtime}/none.kzr"
 fi
 
 runtimedir="${BASE_DIR}/run/runtime"

--- a/rootfs/usr/bin/kazeta
+++ b/rootfs/usr/bin/kazeta
@@ -115,14 +115,14 @@ if [ -n "$runtime_name" ]; then
 				if [ ! -f "$runtime" ]; then
 					runtime="$(ls ${media_path}/${runtime_name}-*.kzr)"
 					if [ ! -f "$runtime" ]; then
-						runtime="{$internal_runtime}/none.kzr"
+						runtime="${internal_runtime}/none.kzr"
 					fi
 				fi
 			fi
 		fi
 	fi
 else
-	runtime="{$internal_runtime}/none.kzr"
+	runtime="${internal_runtime}/none.kzr"
 fi
 
 runtimedir="${BASE_DIR}/run/runtime"

--- a/rootfs/usr/bin/kazeta
+++ b/rootfs/usr/bin/kazeta
@@ -103,16 +103,20 @@ internal_runtime="/usr/share/kazeta/runtimes/"
 
 runtime_name="$(get_attribute 'Runtime' ${cart_info})"
 if [ -n "$runtime_name" ]; then
-	#Checks for a runtime internally that matches
-	runtime="$(ls ${internal_runtime}/${runtime_name}-*.kzr)"
+	#Checking internal path for matching runtime
+	runtime="${internal_runtime}/${runtime_name}.kzr"
 	if [ ! -f "$runtime" ]; then
-		runtime="${media_path}/${runtime_name}"
+		runtime="$(ls ${internal_runtime}/${runtime_name}-*.kzr)"
+		#Checking cart path for matching runtime
 		if [ ! -f "$runtime" ]; then
-			runtime="${media_path}/${runtime_name}.kzr"
+			runtime="${media_path}/${runtime_name}"
 			if [ ! -f "$runtime" ]; then
-				runtime="$(ls ${media_path}/${runtime_name}-*.kzr)"
+				runtime="${media_path}/${runtime_name}.kzr"
 				if [ ! -f "$runtime" ]; then
-					runtime="{$internal_runtime}/none.kzr"
+					runtime="$(ls ${media_path}/${runtime_name}-*.kzr)"
+					if [ ! -f "$runtime" ]; then
+						runtime="{$internal_runtime}/none.kzr"
+					fi
 				fi
 			fi
 		fi

--- a/rootfs/usr/bin/kazeta
+++ b/rootfs/usr/bin/kazeta
@@ -99,7 +99,7 @@ if [[ ! -d "${upper}" ]]; then
 fi
 
 #Directory for all internal runtimes
-internal_runtime="/usr/share/kazeta/runtimes/"
+internal_runtime="/usr/share/kazeta/runtimes"
 
 runtime_name="$(get_attribute 'Runtime' ${cart_info})"
 if [ -n "$runtime_name" ]; then

--- a/rootfs/usr/bin/kazeta
+++ b/rootfs/usr/bin/kazeta
@@ -47,8 +47,8 @@ function cleanup {
 	popd
 	pkexec kazeta-mount --unmount "${target}" "${runtimedir}"
 	pkexec kazeta-mount kzp --unmount "${cart_path}"
-	rm -rf "${upper}/.kazeta/share"
-	rmdir --ignore-fail-on-non-empty "${upper}/.kazeta"
+	rm -rf "${upper}.kazeta/share"
+	rmdir --ignore-fail-on-non-empty "${upper}.kazeta"
 }
 
 # wait up to 2 seconds for a cart


### PR DESCRIPTION
For those wanting to either save space on a cart or fast boot-times when using CD/DVD/BD based cart. This option allows a person with the knowledge to add an internal runtime that will be prioritized over the ones provided by the cart. a wiki tutorial was created here [Internal Runtimes](https://github.com/catsgomoo/kazeta/wiki/Internal-Runtimes)